### PR TITLE
fix(sponsors): Arregla link roto a mozilla.pe

### DIFF
--- a/src/data/sponsors.json
+++ b/src/data/sponsors.json
@@ -11,7 +11,7 @@
   },
   {
     "id": "mozillaperu",
-    "link": "http://mozilla.pe/",
+    "link": "https://www.mozilla.pe/",
     "photoURL": "https://github.com/mozillaperu.png?size=100"
   }
 ]


### PR DESCRIPTION
Este PR arregla link roto en la sección de sponsors reportado en Slack de LimaJS:

![image](https://user-images.githubusercontent.com/110297/60813839-274d0b80-a15a-11e9-9915-b902474e3083.png)

***

Una vez integrado este cambio en `master` habría que volver a ejecutar `yarn deploy` para hacer un nuevo build y actualizar la rama `gh-pages`.